### PR TITLE
Adding transactions to the block page

### DIFF
--- a/src/components/transaction/BlockTransactionsList.tsx
+++ b/src/components/transaction/BlockTransactionsList.tsx
@@ -43,7 +43,7 @@ const mapTransactionData = (
     ),
     size: `${tx.size.toLocaleString()} Bytes`,
     parsedType: (): ReactElement => <ParsedTransactionType type={tx.type} />,
-    type: tx.type,
+    type: tx.type || "contract",
     hash: tx.hash ? tx.hash: tx.txid,
   }
 }

--- a/src/components/transaction/BlockTransactionsList.tsx
+++ b/src/components/transaction/BlockTransactionsList.tsx
@@ -44,7 +44,7 @@ const mapTransactionData = (
     size: `${tx.size.toLocaleString()} Bytes`,
     parsedType: (): ReactElement => <ParsedTransactionType type={tx.type} />,
     type: tx.type,
-    hash: tx.txid,
+    hash: tx.hash ? tx.hash: tx.txid,
   }
 }
 

--- a/src/components/transaction/BlockTransactionsList.tsx
+++ b/src/components/transaction/BlockTransactionsList.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react'
 
-
 import { DetailedBlock } from '../../reducers/blockReducer'
 import List from '../list/List'
 import './BlockTransactionsList.scss'
@@ -24,14 +23,14 @@ const mapTransactionData = (
   block: DetailedBlock,
 ): ParsedTx => {
   return {
-    time: (): ReactElement => <TransactionTime block_time={block.time}/>,
+    time: (): ReactElement => <TransactionTime block_time={block.time} />,
     txid: (): ReactElement => (
       <div className="txid-index-cell"> {tx.txid} </div>
     ),
     size: `${tx.size.toLocaleString()} Bytes`,
     parsedType: (): ReactElement => <ParsedTransactionType type={tx.type} />,
-    type: tx.type || "contract",
-    hash: tx.hash ? tx.hash: tx.txid,
+    type: tx.type || 'contract',
+    hash: tx.hash ? tx.hash : tx.txid,
   }
 }
 

--- a/src/components/transaction/BlockTransactionsList.tsx
+++ b/src/components/transaction/BlockTransactionsList.tsx
@@ -1,8 +1,5 @@
 import React, { ReactElement } from 'react'
-import moment from 'moment'
-import { Icon } from '@iconify/react'
-import DateRangeIcon from '@material-ui/icons/DateRange'
-import clockIcon from '@iconify/icons-simple-line-icons/clock'
+
 
 import { DetailedBlock } from '../../reducers/blockReducer'
 import List from '../list/List'
@@ -11,6 +8,7 @@ import { BlockTransaction } from '../../reducers/transactionReducer'
 import { ROUTES } from '../../constants'
 import useWindowWidth from '../../hooks/useWindowWidth'
 import ParsedTransactionType from './ParsedTransactionType'
+import TransactionTime from './TransactionTime'
 
 type ParsedTx = {
   time: React.FC<{}>
@@ -26,18 +24,7 @@ const mapTransactionData = (
   block: DetailedBlock,
 ): ParsedTx => {
   return {
-    time: (): ReactElement => (
-      <span className="transaction-time-details-row">
-        <div>
-          <DateRangeIcon style={{ color: '#7698A9', fontSize: 20 }} />
-          <span>{moment.unix(block.time).format('MM-DD-YYYY')}</span>
-        </div>
-        <div>
-          <Icon icon={clockIcon} style={{ color: '#7698A9', fontSize: 18 }} />
-          <span>{moment.unix(block.time).format('hh:mm:ss')}</span>
-        </div>
-      </span>
-    ),
+    time: (): ReactElement => <TransactionTime block_time={block.time}/>,
     txid: (): ReactElement => (
       <div className="txid-index-cell"> {tx.txid} </div>
     ),

--- a/src/components/transaction/N3BlockTransactionList.tsx
+++ b/src/components/transaction/N3BlockTransactionList.tsx
@@ -1,0 +1,92 @@
+import React, { ReactElement } from 'react'
+import moment from 'moment'
+import { Icon } from '@iconify/react'
+import DateRangeIcon from '@material-ui/icons/DateRange'
+import clockIcon from '@iconify/icons-simple-line-icons/clock'
+
+import { DetailedBlock } from '../../reducers/blockReducer'
+import List from '../list/List'
+import './BlockTransactionsList.scss'
+import { BlockTransaction } from '../../reducers/transactionReducer'
+import { ROUTES } from '../../constants'
+import useWindowWidth from '../../hooks/useWindowWidth'
+import ParsedTransactionType from './ParsedTransactionType'
+import TransactionTime, { TransactionTimeProps } from './TransactionTime'
+
+
+
+type ParsedTx = {
+  time: React.FC<TransactionTimeProps>
+  txid: React.FC<{}>
+  size: string
+  parsedType: React.FC<{}>
+  hash: string
+}
+
+
+const mapTransactionData = (
+  tx: BlockTransaction,
+  block: DetailedBlock,
+): ParsedTx => {
+  return {
+    time: (): ReactElement => <TransactionTime block_time={block.time}/>,
+    txid: (): ReactElement => (
+      <div className="txid-index-cell"> {tx.hash} </div>
+    ),
+    size: `${tx.size.toLocaleString()} Bytes`,
+    parsedType: (): ReactElement => <ParsedTransactionType type={"contract"} />,
+    hash: tx.hash,
+  }
+}
+
+const returnTxListData = (
+  data: Array<BlockTransaction>,
+  block: DetailedBlock,
+): Array<ParsedTx> => {
+  return data.map(tx => mapTransactionData(tx, block))
+}
+
+const N3BlockTransactionsList: React.FC<{
+  list: Array<BlockTransaction>
+  block: DetailedBlock
+  loading: boolean
+  network: string
+  chain: string
+}> = ({ list, block, loading, network, chain }) => {
+  const width = useWindowWidth()
+
+  const columns =
+    width > 768
+      ? [
+          { name: 'Type', accessor: 'parsedType' },
+          { name: 'Transaction ID', accessor: 'txid' },
+          { name: 'Size', accessor: 'size' },
+          { name: 'Completed on', accessor: 'time' },
+        ]
+      : [
+          { name: 'Type', accessor: 'parsedType' },
+          {
+            name: 'Transaction ID',
+            accessor: 'txid',
+            style: { minWidth: '100px' },
+          },
+          { name: 'Size', accessor: 'size' },
+        ]
+
+  return (
+    <div id="BlockTransactionsList">
+      <List 
+        data={returnTxListData(list, block)}
+        rowId="hash"
+        generateHref={(data): string =>
+          `${ROUTES.TRANSACTION.url}/${chain}/${network}/${data.id}`
+        }
+        isLoading={loading}
+        columns={columns}
+        leftBorderColorOnRow={"#4CFFB3"}
+      />
+    </div>
+  )
+}
+
+export default N3BlockTransactionsList

--- a/src/components/transaction/N3BlockTransactionList.tsx
+++ b/src/components/transaction/N3BlockTransactionList.tsx
@@ -1,8 +1,4 @@
 import React, { ReactElement } from 'react'
-import moment from 'moment'
-import { Icon } from '@iconify/react'
-import DateRangeIcon from '@material-ui/icons/DateRange'
-import clockIcon from '@iconify/icons-simple-line-icons/clock'
 
 import { DetailedBlock } from '../../reducers/blockReducer'
 import List from '../list/List'
@@ -13,8 +9,6 @@ import useWindowWidth from '../../hooks/useWindowWidth'
 import ParsedTransactionType from './ParsedTransactionType'
 import TransactionTime, { TransactionTimeProps } from './TransactionTime'
 
-
-
 type ParsedTx = {
   time: React.FC<TransactionTimeProps>
   txid: React.FC<{}>
@@ -23,18 +17,17 @@ type ParsedTx = {
   hash: string
 }
 
-
 const mapTransactionData = (
   tx: BlockTransaction,
   block: DetailedBlock,
 ): ParsedTx => {
   return {
-    time: (): ReactElement => <TransactionTime block_time={block.time}/>,
+    time: (): ReactElement => <TransactionTime block_time={block.time} />,
     txid: (): ReactElement => (
       <div className="txid-index-cell"> {tx.hash} </div>
     ),
     size: `${tx.size.toLocaleString()} Bytes`,
-    parsedType: (): ReactElement => <ParsedTransactionType type={"contract"} />,
+    parsedType: (): ReactElement => <ParsedTransactionType type={'contract'} />,
     hash: tx.hash,
   }
 }
@@ -75,7 +68,7 @@ const N3BlockTransactionsList: React.FC<{
 
   return (
     <div id="BlockTransactionsList">
-      <List 
+      <List
         data={returnTxListData(list, block)}
         rowId="hash"
         generateHref={(data): string =>
@@ -83,7 +76,7 @@ const N3BlockTransactionsList: React.FC<{
         }
         isLoading={loading}
         columns={columns}
-        leftBorderColorOnRow={"#4CFFB3"}
+        leftBorderColorOnRow={'#4CFFB3'}
       />
     </div>
   )

--- a/src/components/transaction/ParsedTransactionType.tsx
+++ b/src/components/transaction/ParsedTransactionType.tsx
@@ -6,7 +6,7 @@ import Claim from '../../assets/icons/gas-claim-transaction.svg'
 import Miner from '../../assets/icons/miner-transaction.svg'
 import './ParsedTransactionType.scss'
 
-const parseTypeToDiplayValue = (type: string): string => {
+const parseTypeToDiplayValue = (type?: string): string => {
   switch (type) {
     case 'MinerTransaction':
       return 'Miner'
@@ -17,27 +17,27 @@ const parseTypeToDiplayValue = (type: string): string => {
     case 'ContractTransaction':
       return 'Contract'
     default:
-      return 'transparent'
+      return 'Contract'
   }
 }
 
-const parseTypeToIcon = (type: string): ReactElement => {
+const parseTypeToIcon = (type?: string): ReactElement => {
   switch (type) {
     case 'MinerTransaction':
-      return <img src={Miner} alt="invocation-icon" />
+      return <img src={Miner} alt="miner-icon" />
     case 'InvocationTransaction':
       return <img src={Invocation} alt="invocation-icon" />
     case 'ClaimTransaction':
-      return <img src={Claim} alt="invocation-icon" />
+      return <img src={Claim} alt="claim-icon" />
     case 'ContractTransaction':
-      return <img src={Contract} alt="invocation-icon" />
+      return <img src={Contract} alt="contract-icon" />
     default:
-      return <img src={Invocation} alt="invocation-icon" />
+      return <img src={Contract} alt="contract-icon" />
   }
 }
 
 type Props = {
-  type: string
+  type?: string
 }
 
 const ParsedTransactionType: React.FC<Props> = ({ type }: Props) => (

--- a/src/components/transaction/TransactionTime.tsx
+++ b/src/components/transaction/TransactionTime.tsx
@@ -1,25 +1,26 @@
-import moment from "moment"
-import React from "react"
+import moment from 'moment'
+import React from 'react'
 import DateRangeIcon from '@material-ui/icons/DateRange'
 import clockIcon from '@iconify/icons-simple-line-icons/clock'
-import { Icon } from "@iconify/react"
+import { Icon } from '@iconify/react'
 
 export type TransactionTimeProps = {
-    block_time?: number
-  }
-  
-  const TransactionTime: React.FC<TransactionTimeProps> = ({ block_time }: TransactionTimeProps) => (
-    <span className="transaction-time-details-row">
-        <div>
-          <DateRangeIcon style={{ color: '#7698A9', fontSize: 20 }} />
-          <span>{moment.unix(block_time || 0).format('MM-DD-YYYY')}</span>
-        </div>
-        <div>
-          <Icon icon={clockIcon} style={{ color: '#7698A9', fontSize: 18 }} />
-          <span>{moment.unix(block_time || 0).format('hh:mm:ss')}</span>
-        </div>
-      </span>
-  )
-  
-  export default TransactionTime
-  
+  block_time?: number
+}
+
+const TransactionTime: React.FC<TransactionTimeProps> = ({
+  block_time,
+}: TransactionTimeProps) => (
+  <span className="transaction-time-details-row">
+    <div>
+      <DateRangeIcon style={{ color: '#7698A9', fontSize: 20 }} />
+      <span>{moment.unix(block_time || 0).format('MM-DD-YYYY')}</span>
+    </div>
+    <div>
+      <Icon icon={clockIcon} style={{ color: '#7698A9', fontSize: 18 }} />
+      <span>{moment.unix(block_time || 0).format('hh:mm:ss')}</span>
+    </div>
+  </span>
+)
+
+export default TransactionTime

--- a/src/components/transaction/TransactionTime.tsx
+++ b/src/components/transaction/TransactionTime.tsx
@@ -1,0 +1,25 @@
+import moment from "moment"
+import React from "react"
+import DateRangeIcon from '@material-ui/icons/DateRange'
+import clockIcon from '@iconify/icons-simple-line-icons/clock'
+import { Icon } from "@iconify/react"
+
+export type TransactionTimeProps = {
+    block_time?: number
+  }
+  
+  const TransactionTime: React.FC<TransactionTimeProps> = ({ block_time }: TransactionTimeProps) => (
+    <span className="transaction-time-details-row">
+        <div>
+          <DateRangeIcon style={{ color: '#7698A9', fontSize: 20 }} />
+          <span>{moment.unix(block_time || 0).format('MM-DD-YYYY')}</span>
+        </div>
+        <div>
+          <Icon icon={clockIcon} style={{ color: '#7698A9', fontSize: 18 }} />
+          <span>{moment.unix(block_time || 0).format('hh:mm:ss')}</span>
+        </div>
+      </span>
+  )
+  
+  export default TransactionTime
+  

--- a/src/pages/block/Block.tsx
+++ b/src/pages/block/Block.tsx
@@ -154,7 +154,6 @@ const Block: React.FC<Props> = (props: Props) => {
             </div>
           </div>
 
-          {/* TODO: implement the tx list com22ponent for neo3 */}
           {block && !!block.tx.length && chain === 'neo2' && (
             <div className="block-transactions-section">
               <div className="details-section">

--- a/src/pages/block/Block.tsx
+++ b/src/pages/block/Block.tsx
@@ -19,6 +19,7 @@ import BackButton from '../../components/navigation/BackButton'
 import Copy from '../../components/copy/Copy'
 import useUpdateNetworkState from '../../hooks/useUpdateNetworkState'
 import { formatDate, formatHours } from '../../utils/time'
+import N3BlockTransactionsList from '../../components/transaction/N3BlockTransactionList'
 
 interface MatchParams {
   hash: string
@@ -153,13 +154,28 @@ const Block: React.FC<Props> = (props: Props) => {
             </div>
           </div>
 
-          {/* TODO: implement the tx list component for neo3 */}
+          {/* TODO: implement the tx list com22ponent for neo3 */}
           {block && !!block.tx.length && chain === 'neo2' && (
             <div className="block-transactions-section">
               <div className="details-section">
                 <div className="section-label">TRANSACTIONS</div>
 
                 <BlockTransactionsList
+                  loading={isLoading}
+                  list={block.tx}
+                  block={block}
+                  network={network}
+                  chain={chain}
+                />
+              </div>
+            </div>
+          )}
+          {block && !!block.tx.length && chain === 'neo3' && (
+            <div className="block-transactions-section">
+              <div className="details-section">
+                <div className="section-label">TRANSACTIONS</div>
+
+                <N3BlockTransactionsList
                   loading={isLoading}
                   list={block.tx}
                   block={block}

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -119,6 +119,7 @@ export type BlockTransaction = {
   time: number
   txid: string
   type: string
+  hash: string
 }
 
 export const INITIAL_STATE = {

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -118,7 +118,7 @@ export type BlockTransaction = {
   size: number
   time: number
   txid: string
-  type: string
+  type?: string
   hash: string
 }
 


### PR DESCRIPTION
Closes #353 

Note: It is not possible to add the transfers as shown on the designs because there is no efficient way to retrieve it.