### PR TITLE
fix notification to display computed value

### DIFF
--- a/src/components/notification/Notification.tsx
+++ b/src/components/notification/Notification.tsx
@@ -80,7 +80,9 @@ export const NotificationRow: React.FC<{
       selectedOption={(selectedOption.label && selectedOption) || options[0]}
       handleChange={handleChange}
       options={(filteredOptions.length && filteredOptions) || options}
-      computedDisplayValue={convertedValue || value}
+      computedDisplayValue={
+        selectedOption.label === STRING_OPTION.label ? convertedValue : value
+      }
     />
   )
 }


### PR DESCRIPTION
Correctly displays value when swapping options from byte string to string and vice versa

closes issue: https://github.com/CityOfZion/dora/issues/428