### PR TITLE
fix: `SearchResults.tsx` to correctly load searched contract data

### DIFF
--- a/src/pages/search-results/SearchResults.tsx
+++ b/src/pages/search-results/SearchResults.tsx
@@ -128,6 +128,22 @@ const TransactionResult = (result: any): ReactElement => (
   </Link>
 )
 
+const ContractResult = (result: any): ReactElement => (
+  <Link
+    to={`${ROUTES.CONTRACT.url}/${result.protocol}/${result.network}/${result.hash}`}
+  >
+    <div className="search-result-container">
+      <PlatformElement protocol={result.protocol} network={result.network} />
+      <div className="search-results-details">
+        <div className="search-result-type">
+          {ROUTES.CONTRACTS.renderIcon()} Contract
+        </div>
+        <div className="search-result-info"></div>
+      </div>
+    </div>
+  </Link>
+)
+
 const SearchResult = ({ result }: { result: any }): ReactElement => {
   switch (result.type) {
     case 'block':
@@ -136,6 +152,8 @@ const SearchResult = ({ result }: { result: any }): ReactElement => {
       return AddressResult(result)
     case 'transaction':
       return TransactionResult(result)
+    case 'contract':
+      return ContractResult(result)
   }
   return <div />
 }


### PR DESCRIPTION
Example used from issue, contract address: `0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5`: 

API does correctly fetch the contract data: 
![image](https://user-images.githubusercontent.com/41127686/146480538-69374659-4b80-4f6e-af6e-01080a501a01.png)

Issue was located within SearchResults, missing switch case for `result.type` `'contract'`. This was added and now correctly loads search results:
![image](https://user-images.githubusercontent.com/41127686/146480738-24d2c7f1-a202-4f9d-97ca-74213d2de2cf.png)
Final result:
![image](https://user-images.githubusercontent.com/41127686/146480803-7f322584-633c-47e9-86a6-566d5d6c8d0b.png)


closes issue:https://github.com/CityOfZion/dora/issues/427