### PR TITLE
fix(AddressTransactions): make sure the chain is being set on the current network

### DIFF
--- a/src/pages/address/fragments/transactions/AddressTransactions.tsx
+++ b/src/pages/address/fragments/transactions/AddressTransactions.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../../constants'
 import { convertToArbitraryDecimals } from '../../../../utils/formatter'
 import AddressTransactionsCard from './fragments/AddressTransactionCard'
+import useUpdateNetworkState from '../../../../hooks/useUpdateNetworkState'
 
 interface MatchParams {
   hash: string
@@ -27,6 +28,7 @@ type Props = RouteComponentProps<MatchParams>
 
 const AddressTransactions: React.FC<Props> = (props: Props) => {
   const { chain, network, hash } = props.match.params
+  useUpdateNetworkState(props)
   const [transactions, setTransactions] = useState([] as AddressTransaction[])
   const [currentPage, setCurrentPage] = useState(1)
   const [pages, setPages] = useState(0)


### PR DESCRIPTION
We were never updating the networks chain to match the current network, we only set the current chain when we navigate to Assets, which sets the chain and when navigating back to Transactions allowed all of them to load for said address

Before:
```json
{
    "network": "mainnet",
    "chain": ""
}
```

After: 

```json
{
    "network": "mainnet",
    "chain": "neo3"
}
```

https://dora-stage.coz.io/address/neo3/mainnet/NNmTVFrSPhe7zjgN6iq9cLgXJwLZziUKV6/transactions will load upon opening the link / refreshing without switching to Assets etc.


Closes issue: https://github.com/CityOfZion/dora/issues/510