### PR TITLE
fix(nftActions): check asset is not null before mapping the attributes

### DIFF
--- a/src/actions/nftActions.ts
+++ b/src/actions/nftActions.ts
@@ -158,24 +158,26 @@ export function fetchNFTS(ownerId: string, network: string, page = 1) {
       const { assets, total_results } =
         (await response.json()) as GhostMarketAssets
 
-      const nfts = assets.map(({ nft }): NFT => {
-        const attributes = nft.nft_metadata.attributes
-          ? mapAttributes(nft.nft_metadata.attributes)
-          : []
+      const nfts = assets
+        ? assets.map(({ nft }): NFT => {
+            const attributes = nft.nft_metadata.attributes
+              ? mapAttributes(nft.nft_metadata.attributes)
+              : []
 
-        return {
-          name: nft.nft_metadata.name || '',
-          chain: nft.chain || '',
-          image: treatNFTImage(nft.nft_metadata.image || ''),
-          id: nft.token_id || '',
-          contract: nft.contract || '',
-          collection: {
-            image: nft.collection.featured_image || '',
-            name: nft.collection.name || '',
-          },
-          attributes,
-        }
-      })
+            return {
+              name: nft.nft_metadata.name || '',
+              chain: nft.chain || '',
+              image: treatNFTImage(nft.nft_metadata.image || ''),
+              id: nft.token_id || '',
+              contract: nft.contract || '',
+              collection: {
+                image: nft.collection.featured_image || '',
+                name: nft.collection.name || '',
+              },
+              attributes,
+            }
+          })
+        : []
 
       dispatch(requestNFTSSuccess(nfts, page, total_results))
     } catch (e) {


### PR DESCRIPTION
I see https://github.com/CityOfZion/dora/issues/514 was fixed in this PR: https://github.com/CityOfZion/dora/blob/develop/src/actions/nftActions.ts#L28-L33.

Small edge case where the `asset` from the response _can_ be null and throws error in console (not a big deal just saw this while looking at this ticket) logs below: 

```sh
TypeError: Cannot read properties of null (reading 'map')
    at nftActions.ts:181:1
```

Address used: NekqQM4kT6MESNoFjyrpnnFPi2au6VLkAU (Testnet where no assets are present)


Closes issue: https://github.com/CityOfZion/dora/issues/514