### PR TITLE
fix: use 24 hour format for Blocks and Transactions

### DIFF
--- a/src/components/transaction/TransactionTime.tsx
+++ b/src/components/transaction/TransactionTime.tsx
@@ -13,12 +13,12 @@ const TransactionTime: React.FC<TransactionTimeProps> = ({
 }: TransactionTimeProps) => (
   <span className="transaction-time-details-row">
     <div>
-      <DateRangeIcon style={{ color: '#7698A9', fontSize: 20 }} />
-      <span>{moment.unix(block_time || 0).format('MM-DD-YYYY')}</span>
+      <Icon icon={clockIcon} style={{ color: '#7698A9', fontSize: 18 }} />
+      <span>{moment.unix(block_time || 0).format('HH:mm:ss')}</span>
     </div>
     <div>
-      <Icon icon={clockIcon} style={{ color: '#7698A9', fontSize: 18 }} />
-      <span>{moment.unix(block_time || 0).format('hh:mm:ss')}</span>
+      <DateRangeIcon style={{ color: '#7698A9', fontSize: 20 }} />
+      <span>{moment.unix(block_time || 0).format('MM-DD-YYYY')}</span>
     </div>
   </span>
 )

--- a/src/pages/block/Block.tsx
+++ b/src/pages/block/Block.tsx
@@ -18,7 +18,7 @@ import Breadcrumbs from '../../components/navigation/Breadcrumbs'
 import BackButton from '../../components/navigation/BackButton'
 import Copy from '../../components/copy/Copy'
 import useUpdateNetworkState from '../../hooks/useUpdateNetworkState'
-import { formatDate, formatHours } from '../../utils/time'
+import { format24Hours, formatDate } from '../../utils/time'
 import N3BlockTransactionsList from '../../components/transaction/N3BlockTransactionList'
 
 interface MatchParams {
@@ -119,7 +119,7 @@ const Block: React.FC<Props> = (props: Props) => {
                             icon={clockIcon}
                             style={{ color: '#7698A9', fontSize: 18 }}
                           />
-                          {formatHours(block.time)}
+                          {format24Hours(block.time)}
                         </>
                       )}
                     </div>

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -67,6 +67,9 @@ export const formatDate = (time: string | number): string =>
 export const formatHours = (time: string | number): string =>
   moment.unix(Number(time)).format('hh:mm:ss')
 
+export const format24Hours = (time: string | number): string =>
+  moment.unix(Number(time)).format('HH:mm:ss')
+
 type ListUnionType = (Block | Transaction | Contract)[]
 
 export const sortedByDate = (


### PR DESCRIPTION
Using 24 hour format for block and transaction times: 

Block: 
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/41127686/160241355-a6fef94f-af59-4ef6-bf12-f0e3b78507aa.png">

Transactions: 
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/41127686/160241375-cebc2083-1ab6-40ef-946d-eb8c5b555e6e.png">

Closes issue: https://github.com/CityOfZion/dora/issues/456