### PR TITLE
Show block list on dashboard even if one of the endpoints fails.

### DIFF
--- a/src/actions/blockActions.ts
+++ b/src/actions/blockActions.ts
@@ -164,15 +164,13 @@ export function fetchBlocks(page = 1, chain?: string) {
           }
         }),
       )
-      let cleanedResults = res.filter(r => r['status'] === 'fulfilled')
-      // @ts-ignore
-      cleanedResults = cleanedResults.map(r => r['value'])
-      // @ts-ignore
-      const cleanedBlocks = cleanedResults
-        .flat()
-        .filter(r => r !== undefined) as Block[]
+      const cleanedBlocks = res
+        .filter(it => it.status === 'fulfilled' && it.value)
+        .map(it => (it as PromiseFulfilledResult<Block[]>).value)
+        .flat() as Block[]
+
       const all = {
-        items: sortSingleListByDate(cleanedBlocks) as Block[],
+        items: sortSingleListByDate(cleanedBlocks),
       }
       dispatch(requestBlocksSuccess(page, { all }))
     } catch (e) {

--- a/src/components/block/DashboardBlockList.tsx
+++ b/src/components/block/DashboardBlockList.tsx
@@ -108,12 +108,12 @@ const DashboardBlockList: React.FC<{ network: string }> = ({ network }) => {
           <h4>Neo N3 (Mainnet)</h4>
           <div className="list-wrapper">
             <List
-              data={returnBlockListData(neo3List, blockState.isLoading)}
+              data={returnBlockListData(neo3List, blockState.isLoading || neo3List.length === 0)}
               rowId="height"
               generateHref={(data): string =>
                 `${ROUTES.BLOCK.url}/neo3/mainnet/${data.id}`
               }
-              isLoading={blockState.isLoading}
+              isLoading={blockState.isLoading || neo3List.length === 0}
               columns={columns}
               leftBorderColorOnRow="#D355E7"
             />
@@ -124,12 +124,12 @@ const DashboardBlockList: React.FC<{ network: string }> = ({ network }) => {
         <h4>Neo Legacy (Mainnet)</h4>
         <div className="list-wrapper">
           <List
-            data={returnBlockListData(neo2List, blockState.isLoading)}
+            data={returnBlockListData(neo2List, blockState.isLoading || neo2List.length === 0)}
             rowId="height"
             generateHref={(data): string =>
               `${ROUTES.BLOCK.url}/neo2/${network}/${data.id}`
             }
-            isLoading={blockState.isLoading}
+            isLoading={blockState.isLoading || neo2List.length === 0}
             columns={columns}
             leftBorderColorOnRow="#D355E7"
           />


### PR DESCRIPTION
related #559 

The issue described touches on 3 parts
1. Block list
2. Transaction list
3. Contract invocations

This attempts to provide a (temporary) solution for `1.` where if 1 of the end points fails the data for the other one will still show. It's not ideal because it is not clear to the end user that some data feed failed and therefore the user might keep waiting until data will show (as it looks like a place holder).

Example
![image](https://user-images.githubusercontent.com/6625537/164181412-84059f74-b736-4a2b-ad73-c67050ec92a0.png)

I think we need some design input (@J-G-W) on what to show if the data feed is not available. I now had 2 other options
1. show no data - which looks ugly
![Screenshot from 2022-04-20 09-51-21](https://user-images.githubusercontent.com/6625537/164181657-1eec2a0e-78b5-4bcd-90f6-d3fe3549576e.png)
2. show dummy data (see the NEO2 list) - which seems bad as users might think these are the latest produced blocks?
![image](https://user-images.githubusercontent.com/6625537/164181851-35721414-586f-48f5-a9de-44dc993f2641.png)
 