### PR TITLE
Speed up DashBoard loading

### DIFF
--- a/src/actions/blockActions.ts
+++ b/src/actions/blockActions.ts
@@ -4,7 +4,6 @@ import { ThunkDispatch } from 'redux-thunk'
 import {
   GENERATE_BASE_URL,
   NEO_MAINNET_PLATFORMS,
-  Platform,
   SUPPORTED_PLATFORMS,
 } from '../constants'
 import { Block, State } from '../reducers/blockReducer'
@@ -139,7 +138,7 @@ export function fetchBlock(indexOrHash: string | number = 1) {
 export function fetchBlocks(
   page = 1,
   chain?: string,
-  supportedPlatforms?: Platform[],
+  supportedPlatforms = SUPPORTED_PLATFORMS,
 ) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,
@@ -148,13 +147,8 @@ export function fetchBlocks(
     try {
       dispatch(requestBlocks(page))
 
-      const platforms =
-        supportedPlatforms === undefined
-          ? SUPPORTED_PLATFORMS
-          : supportedPlatforms
-
       const res = await Promise.allSettled(
-        platforms.map(async ({ network, protocol }) => {
+        supportedPlatforms.map(async ({ network, protocol }) => {
           let result: BlocksResponse | NLBlocksResponse | undefined = undefined
           if (protocol === 'neo2') {
             result = await NeoLegacyREST.blocks(page, network)

--- a/src/actions/blockActions.ts
+++ b/src/actions/blockActions.ts
@@ -4,6 +4,7 @@ import { ThunkDispatch } from 'redux-thunk'
 import {
   GENERATE_BASE_URL,
   NEO_MAINNET_PLATFORMS,
+  Platform,
   SUPPORTED_PLATFORMS,
 } from '../constants'
 import { Block, State } from '../reducers/blockReducer'
@@ -138,7 +139,7 @@ export function fetchBlock(indexOrHash: string | number = 1) {
 export function fetchBlocks(
   page = 1,
   chain?: string,
-  supportedPlatforms = SUPPORTED_PLATFORMS,
+  supportedPlatforms: Platform[] = SUPPORTED_PLATFORMS,
 ) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,

--- a/src/actions/blockActions.ts
+++ b/src/actions/blockActions.ts
@@ -1,7 +1,12 @@
 import { Dispatch, Action } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 
-import { GENERATE_BASE_URL, SUPPORTED_PLATFORMS } from '../constants'
+import {
+  GENERATE_BASE_URL,
+  NEO_MAINNET_PLATFORMS,
+  Platform,
+  SUPPORTED_PLATFORMS,
+} from '../constants'
 import { Block, State } from '../reducers/blockReducer'
 import { sortSingleListByDate } from '../utils/time'
 import { NeoLegacyREST, NeoRest } from '@cityofzion/dora-ts/dist/api'
@@ -131,7 +136,11 @@ export function fetchBlock(indexOrHash: string | number = 1) {
   }
 }
 
-export function fetchBlocks(page = 1, chain?: string) {
+export function fetchBlocks(
+  page = 1,
+  chain?: string,
+  supportedPlatforms?: Platform[],
+) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,
     getState: () => { block: State },
@@ -139,8 +148,13 @@ export function fetchBlocks(page = 1, chain?: string) {
     try {
       dispatch(requestBlocks(page))
 
+      const platforms =
+        supportedPlatforms === undefined
+          ? SUPPORTED_PLATFORMS
+          : supportedPlatforms
+
       const res = await Promise.allSettled(
-        SUPPORTED_PLATFORMS.map(async ({ network, protocol }) => {
+        platforms.map(async ({ network, protocol }) => {
           let result: BlocksResponse | NLBlocksResponse | undefined = undefined
           if (protocol === 'neo2') {
             result = await NeoLegacyREST.blocks(page, network)
@@ -177,4 +191,8 @@ export function fetchBlocks(page = 1, chain?: string) {
       dispatch(requestBlockError(page, e))
     }
   }
+}
+
+export function fetchMainNetBlocks(page = 1, chain?: string) {
+  return fetchBlocks(page, chain, NEO_MAINNET_PLATFORMS)
 }

--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -1,7 +1,12 @@
 import { Dispatch, Action } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 
-import { GENERATE_BASE_URL, SUPPORTED_PLATFORMS } from '../constants'
+import {
+  GENERATE_BASE_URL,
+  NEO_MAINNET_PLATFORMS,
+  Platform,
+  SUPPORTED_PLATFORMS,
+} from '../constants'
 import { State as NetworkState } from '../reducers/networkReducer'
 import { State, Transaction } from '../reducers/transactionReducer'
 import { sortSingleListByDate } from '../utils/time'
@@ -145,7 +150,7 @@ export function fetchTransaction(hash: string, chain: string) {
   }
 }
 
-export function fetchTransactions(page = 1) {
+export function fetchTransactions(page = 1, supportedPlatforms?: Platform[]) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,
     getState: () => { transaction: State },
@@ -156,8 +161,14 @@ export function fetchTransactions(page = 1) {
       interface TransactionsResponseShunt extends NLTransactionsResponse {
         items: any[]
       }
+
+      const platforms =
+        supportedPlatforms === undefined
+          ? SUPPORTED_PLATFORMS
+          : supportedPlatforms
+
       let res = await Promise.all(
-        SUPPORTED_PLATFORMS.map(async ({ network, protocol }) => {
+        platforms.map(async ({ network, protocol }) => {
           let result:
             | TransactionsResponseShunt
             | TransactionsResponse
@@ -196,4 +207,8 @@ export function fetchTransactions(page = 1) {
       dispatch(requestTransactionsError(page, e))
     }
   }
+}
+
+export function fetchMainNetTransactions(page = 1) {
+  return fetchTransactions(page, NEO_MAINNET_PLATFORMS)
 }

--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -4,7 +4,6 @@ import { ThunkDispatch } from 'redux-thunk'
 import {
   GENERATE_BASE_URL,
   NEO_MAINNET_PLATFORMS,
-  Platform,
   SUPPORTED_PLATFORMS,
 } from '../constants'
 import { State as NetworkState } from '../reducers/networkReducer'
@@ -150,7 +149,10 @@ export function fetchTransaction(hash: string, chain: string) {
   }
 }
 
-export function fetchTransactions(page = 1, supportedPlatforms?: Platform[]) {
+export function fetchTransactions(
+  page = 1,
+  supportedPlatforms = SUPPORTED_PLATFORMS,
+) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,
     getState: () => { transaction: State },
@@ -162,13 +164,8 @@ export function fetchTransactions(page = 1, supportedPlatforms?: Platform[]) {
         items: any[]
       }
 
-      const platforms =
-        supportedPlatforms === undefined
-          ? SUPPORTED_PLATFORMS
-          : supportedPlatforms
-
       let res = await Promise.all(
-        platforms.map(async ({ network, protocol }) => {
+        supportedPlatforms.map(async ({ network, protocol }) => {
           let result:
             | TransactionsResponseShunt
             | TransactionsResponse

--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -4,6 +4,7 @@ import { ThunkDispatch } from 'redux-thunk'
 import {
   GENERATE_BASE_URL,
   NEO_MAINNET_PLATFORMS,
+  Platform,
   SUPPORTED_PLATFORMS,
 } from '../constants'
 import { State as NetworkState } from '../reducers/networkReducer'
@@ -151,7 +152,7 @@ export function fetchTransaction(hash: string, chain: string) {
 
 export function fetchTransactions(
   page = 1,
-  supportedPlatforms = SUPPORTED_PLATFORMS,
+  supportedPlatforms: Platform[] = SUPPORTED_PLATFORMS,
 ) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,

--- a/src/components/block/DashboardBlockList.tsx
+++ b/src/components/block/DashboardBlockList.tsx
@@ -9,7 +9,7 @@ import {
 import { MOCK_BLOCK_LIST_DATA } from '../../utils/mockData'
 import List from '../../components/list/List'
 import { useDispatch, useSelector } from 'react-redux'
-import { fetchBlocks } from '../../actions/blockActions'
+import { fetchMainNetBlocks } from '../../actions/blockActions'
 import { Block, State as BlockState } from '../../reducers/blockReducer'
 import { ROUTES } from '../../constants'
 import useWindowWidth from '../../hooks/useWindowWidth'
@@ -78,7 +78,7 @@ const DashboardBlockList: React.FC<{ network: string }> = ({ network }) => {
   )
 
   useEffect(() => {
-    if (!neo2List.length) dispatch(fetchBlocks())
+    if (!neo2List.length) dispatch(fetchMainNetBlocks())
   }, [dispatch, neo2List.length])
 
   const columns =

--- a/src/components/transaction/DashboardTransactionsList.tsx
+++ b/src/components/transaction/DashboardTransactionsList.tsx
@@ -8,7 +8,7 @@ import {
 import { MOCK_TX_LIST_DATA } from '../../utils/mockData'
 import List from '../list/List'
 import { useDispatch, useSelector } from 'react-redux'
-import { fetchTransactions } from '../../actions/transactionActions'
+import { fetchMainNetTransactions } from '../../actions/transactionActions'
 import {
   Transaction,
   State as TxState,
@@ -69,7 +69,7 @@ const DashboardTransactionsList: React.FC<Props> = ({ network }) => {
   )
 
   useEffect(() => {
-    if (!neo2List.length) dispatch(fetchTransactions())
+    if (!neo2List.length) dispatch(fetchMainNetTransactions())
   }, [dispatch, neo2List.length])
 
   const columns =

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -65,11 +65,24 @@ export const ASSETS = [
   },
 ]
 
-export const SUPPORTED_PLATFORMS = [
+export type Platform = {
+  protocol: string
+  network: string
+}
+
+export const NEO_MAINNET_PLATFORMS = [
   { protocol: 'neo3', network: 'mainnet' },
-  { protocol: 'neo3', network: 'testnet' },
   { protocol: 'neo2', network: 'mainnet' },
+]
+
+export const NEO_TESTNET_PLATFORMS = [
+  { protocol: 'neo3', network: 'testnet' },
   { protocol: 'neo2', network: 'testnet' },
+]
+
+export const SUPPORTED_PLATFORMS = [
+  ...NEO_MAINNET_PLATFORMS,
+  ...NEO_TESTNET_PLATFORMS,
 ]
 
 export const treatNetwork = (network: string) => {


### PR DESCRIPTION
This morning I was looking at slow loading transactions on Dora again and decided to check the network response times. Here's a summary 
![Screenshot from 2022-11-04 12-08-22](https://user-images.githubusercontent.com/6625537/199980631-ad08ee03-ae90-4b70-9539-5b665df8ceea.png)

As can be seen from the table **all** TestNet endpoints are slower than the MainNet endpoints. Maybe they're on different hardware, I don't know. What I do know is that the front page doesn't even show Testnet data. So we're loading it for no reason. 

This PR makes it so we only load mainnet data. I ended up not changing the `invocation stats` loading (shown at the bottom of the page) as that is small and fast anyway.
