### PR TITLE
Use dora-ts part #1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23834,7 +23834,7 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
     "string-length": {

--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -119,22 +119,16 @@ export function fetchTransaction(hash: string, chain: string) {
       dispatch(requestTransaction(hash))
 
       const [network] = getNetworkAndProtocol()
-      const transactionRequestPromises: Promise<any>[] = []
-      if (chain === 'neo3') {
-        transactionRequestPromises.push(NeoRest.transaction(hash, network))
-        transactionRequestPromises.push(NeoRest.log(hash, network))
-      } else {
-        transactionRequestPromises.push(
-          NeoLegacyREST.transaction(hash, network),
-        )
-        transactionRequestPromises.push(NeoLegacyREST.log(hash, network))
-        transactionRequestPromises.push(
-          NeoLegacyREST.transactionAbstracts(hash, network),
-        )
-      }
-
+      const requests: Promise<any>[] =
+        chain === 'neo3'
+          ? [NeoRest.transaction(hash, network), NeoRest.log(hash, network)]
+          : [
+              NeoLegacyREST.transaction(hash, network),
+              NeoLegacyREST.log(hash, network),
+              NeoLegacyREST.transactionAbstracts(hash, network),
+            ]
       try {
-        const responses = await Promise.all(transactionRequestPromises)
+        const responses = await Promise.all(requests)
         const mergedResponse = {}
         for (const response of responses) {
           Object.assign(mergedResponse, response)

--- a/src/pages/address/fragments/transactions/AddressTransactions.tsx
+++ b/src/pages/address/fragments/transactions/AddressTransactions.tsx
@@ -9,14 +9,12 @@ import {
 } from './AddressTransaction'
 import Button from '../../../../components/button/Button'
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
-import {
-  byteStringToAddress,
-  GENERATE_BASE_URL,
-  ROUTES,
-} from '../../../../constants'
+import { byteStringToAddress, ROUTES } from '../../../../constants'
 import { convertToArbitraryDecimals } from '../../../../utils/formatter'
 import AddressTransactionsCard from './fragments/AddressTransactionCard'
 import useUpdateNetworkState from '../../../../hooks/useUpdateNetworkState'
+import { getNetworkAndProtocol } from '../../../../utils/chain'
+import { NeoLegacyREST, NeoRest } from '@cityofzion/dora-ts/dist/api'
 
 interface MatchParams {
   hash: string
@@ -53,13 +51,11 @@ const AddressTransactions: React.FC<Props> = (props: Props) => {
         .map(async ({ contract, state }): Promise<Transfer> => {
           const [{ value: from }, { value: to }, { value: amount }] = state
 
-          const response = await fetch(
-            `${GENERATE_BASE_URL()}/asset/${contract}`,
-          )
+          const [network, protocol] = getNetworkAndProtocol()
+          const restAPI = protocol === 'neo3' ? NeoRest : NeoLegacyREST
+          const json: any = await restAPI.asset(contract, network)
 
-          const json = await response.json()
           const { symbol, decimals } = json
-
           const convertedAmount = convertToArbitraryDecimals(
             Number(amount),
             decimals,

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,0 +1,8 @@
+import { treatNetwork } from '../constants'
+import { store } from '../store'
+
+export function getNetworkAndProtocol(): [string, string] {
+  const network = treatNetwork(store.getState().network.network)
+  const chain = store.getState().network.chain
+  return [network, chain]
+}

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -2,7 +2,6 @@ import { treatNetwork } from '../constants'
 import { store } from '../store'
 
 export function getNetworkAndProtocol(): [string, string] {
-  const network = treatNetwork(store.getState().network.network)
-  const chain = store.getState().network.chain
-  return [network, chain]
+  const { network, chain } = store.getState().network
+  return [treatNetwork(network), chain]
 }


### PR DESCRIPTION
The idea of this PR is to make Dora always make use of [dora-sdk-ts](https://github.com/CityOfZion/dora-sdk-ts) instead of using `dora-sdk-ts` in some parts and other parts manual calling end points using `fetch` and `GENERATE_BASE_URL()`
https://github.com/CityOfZion/dora/blob/778cdc51b4b7ce8158fade6fd25a8125e6d450ef/src/constants.tsx#L97-L108

This should make switching to the Dora v2 backend (once ready) a matter of updating `dora-sdk-ts` version and that's it. 

