### PR TITLE
Cleanup homepage

### DIFF
--- a/src/components/block/DashboardBlockList.tsx
+++ b/src/components/block/DashboardBlockList.tsx
@@ -103,7 +103,6 @@ const DashboardBlockList: React.FC<{ network: string }> = ({ network }) => {
     <div className="multi-chain-dashboard-list">
       <div className="block-list-chain-container">
         <div>
-          <h4>Neo N3 (Mainnet)</h4>
           <div className="label-wrapper-2">
             <Button
               primary

--- a/src/components/contract-invocation/ContractsInvocations.tsx
+++ b/src/components/contract-invocation/ContractsInvocations.tsx
@@ -11,8 +11,6 @@ import { fetchContractsInvocations } from '../../actions/contractActions'
 import useWindowWidth from '../../hooks/useWindowWidth'
 import { Link } from 'react-router-dom'
 import { ROUTES } from '../../constants'
-import Filter, { Platform } from '../filter/Filter'
-import useFilterState from '../../hooks/useFilterState'
 
 type Invocation = {
   name: string
@@ -96,20 +94,10 @@ const ContractsInvocations: React.FC<{}> = () => {
   )
   const { contractsInvocations, isLoading } = contractState
   const width = useWindowWidth()
-
-  const { protocol, handleSetFilterData, network } = useFilterState()
   const selectedData = (): Array<any> => {
-    if (protocol === 'all' && network === 'all') {
-      return contractsInvocations
-    } else if (protocol === 'all' && network !== 'all') {
-      return contractsInvocations.filter(d => d.network === network)
-    } else if (protocol !== 'all' && network === 'all') {
-      return contractsInvocations.filter(d => d.protocol === protocol)
-    } else {
-      return contractsInvocations.filter(
-        d => d.protocol === protocol && d.network === network,
-      )
-    }
+    return contractsInvocations.filter(
+      d => d.network === 'mainnet' && d.protocol === 'neo3',
+    )
   }
 
   useEffect(() => {
@@ -138,14 +126,6 @@ const ContractsInvocations: React.FC<{}> = () => {
     <div>
       <div className="label-wrapper">
         <label>Contract Invocations in the last 24 hours</label>
-        <Filter
-          handleFilterUpdate={(option): void => {
-            handleSetFilterData({
-              protocol: (option.value as Platform).protocol,
-              network: (option.value as Platform).network,
-            })
-          }}
-        />
       </div>
       <div
         id="ContractInvocations"

--- a/src/components/transaction/DashboardTransactionsList.tsx
+++ b/src/components/transaction/DashboardTransactionsList.tsx
@@ -85,7 +85,6 @@ const DashboardTransactionsList: React.FC<Props> = ({ network }) => {
     <div className="multi-chain-dashboard-list">
       <div className="block-list-chain-container">
         <div>
-          <h4>Neo N3 (Mainnet) </h4>
           <div className="label-wrapper-2">
             <Button
               primary


### PR DESCRIPTION
Follow up on https://github.com/CityOfZion/dora/pull/617#issuecomment-1453756707

My initial thought was to move the `Filter` from `contract invocation` to above the block/transaction lists, but then I wondered how to display when the filter is set to `all`. Ideally you'd just have `mainnet` or `testnet` but that makes it inconsistent with the filter on the other pages. For now I settled on "the homepage always displays MainNet".

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/6625537/222795331-9d7c8824-4378-4e65-ba8d-4df49e1f8701.png">
