### PR TITLE
use dora-sdk-ts

### DIFF
--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -154,11 +154,11 @@ export function fetchTransactions(
         supportedPlatforms.map(async ({ network, protocol }) => {
           const result = await NeoRest.transactions(page, network)
           return result.items.map(
-            tx =>
+            ({ time, hash, size }) =>
               ({
-                size: tx.size,
-                time: Number(tx.time),
-                txid: tx.hash,
+                size,
+                time: Number(time),
+                txid: hash,
                 protocol: protocol,
                 network: network,
               } as Transaction),

--- a/src/pages/address/fragments/transactions/AddressTransactions.tsx
+++ b/src/pages/address/fragments/transactions/AddressTransactions.tsx
@@ -9,10 +9,11 @@ import {
 } from './AddressTransaction'
 import Button from '../../../../components/button/Button'
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
-import { byteStringToAddress, GENERATE_BASE_URL } from '../../../../constants'
+import { byteStringToAddress } from '../../../../constants'
 import { convertToArbitraryDecimals } from '../../../../utils/formatter'
 import AddressTransactionsCard from './fragments/AddressTransactionCard'
 import useUpdateNetworkState from '../../../../hooks/useUpdateNetworkState'
+import { NeoRest } from '@cityofzion/dora-ts/dist/api'
 
 interface MatchParams {
   hash: string
@@ -49,16 +50,12 @@ const AddressTransactions: React.FC<Props> = (props: Props) => {
         .map(async ({ contract, state }): Promise<Transfer> => {
           const [{ value: from }, { value: to }, { value: amount }] = state
 
-          const response = await fetch(
-            `${GENERATE_BASE_URL()}/asset/${contract}`,
-          )
-
-          const json = await response.json()
+          const json = await NeoRest.asset(contract, network)
           const { symbol, decimals } = json
 
           const convertedAmount = convertToArbitraryDecimals(
             Number(amount),
-            decimals,
+            Number(decimals),
           )
 
           const convertedFrom = from ? byteStringToAddress(from) : 'mint'

--- a/src/pages/transactions/Transactions.tsx
+++ b/src/pages/transactions/Transactions.tsx
@@ -13,7 +13,6 @@ import {
   State as TxState,
 } from '../../reducers/transactionReducer'
 import Breadcrumbs from '../../components/navigation/Breadcrumbs'
-import ParsedTransactionType from '../../components/transaction/ParsedTransactionType'
 import PlatformCell from '../../components/platform-cell/PlatformCell'
 import Filter, { Platform } from '../../components/filter/Filter'
 import useWindowWidth from '../../hooks/useWindowWidth'
@@ -25,8 +24,6 @@ type ParsedTx = {
   txid: React.FC<{}>
   size: string
   hash: string
-  type: string
-  parsedType: React.FC<{}>
   platform: React.FC<{}>
   chain: string
   href: string
@@ -48,10 +45,6 @@ const mapTransactionData = (tx: Transaction): ParsedTx => {
     ),
     size: `${tx.size.toLocaleString()} Bytes`,
     hash: tx.hash || tx.txid,
-    type: tx.type,
-    parsedType: (): ReactElement => (
-      <ParsedTransactionType type={tx.type || 'ContractTransaction'} />
-    ),
     chain: tx.protocol || '',
     href: `${ROUTES.TRANSACTION.url}/${tx.protocol}/${tx.network}/${
       tx.hash || tx.txid

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -34,7 +34,6 @@ export type Transaction = {
   size: number
   time: number
   txid: string
-  type: string
   hash?: string
   protocol?: string
   network?: string

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -1,3 +1,5 @@
+import { Transaction } from '../reducers/transactionReducer'
+
 export const MOCK_BLOCK_LIST_DATA = [
   {
     index: 786786,
@@ -145,99 +147,15 @@ export const MOCK_BLOCK_LIST_DATA = [
   },
 ]
 
-export const MOCK_TX_LIST_DATA = [
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-  {
-    time: 666,
-    size: 666,
-    txid: '',
-    type: '',
-  },
-]
-
+export const MOCK_TX_LIST_DATA = Array.from(
+  { length: 15 },
+  (_, i) =>
+    ({
+      time: 666,
+      size: 666,
+      hash: '',
+    } as Transaction),
+)
 export const MOCK_CONTRACT_LIST_DATA = [
   {
     block: 5785119,


### PR DESCRIPTION
I tried to change the code to use `dora-sdk-ts` interfaces instead of having internal ones, but it turned out to be futile. Ultimately components expected data as specific types such as `ParsedTx` and thus we're not gaining anything. At some point it also became unclear to me what the correct place is for data transformations as I sometimes see it happen in components and other times in reducers. I ended up ditching the branch and am now opting to just make sure we're not doing any manual `fetch()`'s and just use the REST interfaces provided by `dora-sdk-ts` so the switch to backend v2 becomes easy.

fwiw; the dora-sdk-ts version update is not strictly necessary, but we'll have to do that at some point and it's useful in for testing with the `/v2/` backend