### PR TITLE
use dora-sdk-ts part 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@chakra-ui/react": "^1.8.8",
-    "@cityofzion/dora-ts": "^0.0.6",
+    "@cityofzion/dora-ts": "^0.0.12",
     "@cityofzion/neon-js": "^5.0.0",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",

--- a/src/actions/blockActions.ts
+++ b/src/actions/blockActions.ts
@@ -2,26 +2,24 @@ import { Dispatch, Action } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 
 import {
-  GENERATE_BASE_URL,
   NEO_MAINNET_PLATFORMS,
   Platform,
   SUPPORTED_PLATFORMS,
 } from '../constants'
 import { Block, State } from '../reducers/blockReducer'
 import { sortSingleListByDate } from '../utils/time'
-import { NeoLegacyREST, NeoRest } from '@cityofzion/dora-ts/dist/api'
-import { BlocksResponse } from '@cityofzion/dora-ts/dist/interfaces/api/neo'
-import { BlocksResponse as NLBlocksResponse } from '@cityofzion/dora-ts/dist/interfaces/api/neo_legacy'
+import { NeoRest } from '@cityofzion/dora-ts/dist/api'
+import { store } from '../store'
 
 export const REQUEST_BLOCK = 'REQUEST_BLOCK'
 // We can dispatch this action if requesting
-// block by height (index) or by its hash
+// block by height (index)
 export const requestBlock =
-  (indexOrHash: string | number) =>
+  (index: number) =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: REQUEST_BLOCK,
-      indexOrHash,
+      index: index,
     })
   }
 
@@ -60,11 +58,11 @@ export const requestBlocksSuccess =
 
 export const REQUEST_BLOCK_ERROR = 'REQUEST_BLOCK_ERROR'
 export const requestBlockError =
-  (indexOrHash: string | number, error: Error) =>
+  (index: number, error: Error) =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: REQUEST_BLOCK_ERROR,
-      indexOrHash,
+      index,
       error,
       receivedAt: Date.now(),
     })
@@ -94,7 +92,7 @@ export const clearList =
 
 export function shouldFetchBlock(
   state: { block: State },
-  indexOrHash: string | number,
+  index: number,
 ): boolean {
   return true
 
@@ -116,21 +114,20 @@ export const resetBlockState =
     })
   }
 
-export function fetchBlock(indexOrHash: string | number = 1) {
+export function fetchBlock(index = 1) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,
     getState: () => { block: State },
   ): Promise<void> => {
-    if (shouldFetchBlock(getState(), indexOrHash)) {
-      dispatch(requestBlock(indexOrHash))
+    if (shouldFetchBlock(getState(), index)) {
+      dispatch(requestBlock(index))
       try {
-        const response = await fetch(
-          `${GENERATE_BASE_URL()}/block/${indexOrHash}`,
-        )
-        const json = await response.json()
-        dispatch(requestBlockSuccess(json))
+        const network = store.getState().network.network
+        const response = await NeoRest.block(index, network)
+
+        dispatch(requestBlockSuccess(response as unknown as Block))
       } catch (e) {
-        dispatch(requestBlockError(indexOrHash, e))
+        dispatch(requestBlockError(index, e))
       }
     }
   }
@@ -150,12 +147,7 @@ export function fetchBlocks(
 
       const res = await Promise.allSettled(
         supportedPlatforms.map(async ({ network, protocol }) => {
-          let result: BlocksResponse | NLBlocksResponse | undefined = undefined
-          if (protocol === 'neo2') {
-            result = await NeoLegacyREST.blocks(page, network)
-          } else if (protocol === 'neo3') {
-            result = await NeoRest.blocks(page, network)
-          }
+          const result = await NeoRest.blocks(page, network)
           if (result) {
             return result.items.map(d => {
               const parsed: Block = {

--- a/src/components/transaction/N3BlockTransactionList.tsx
+++ b/src/components/transaction/N3BlockTransactionList.tsx
@@ -19,10 +19,10 @@ type ParsedTx = {
 
 const mapTransactionData = (
   tx: BlockTransaction,
-  block: DetailedBlock,
+  block_time: number,
 ): ParsedTx => {
   return {
-    time: (): ReactElement => <TransactionTime block_time={block.time} />,
+    time: (): ReactElement => <TransactionTime block_time={block_time} />,
     txid: (): ReactElement => (
       <div className="txid-index-cell"> {tx.hash} </div>
     ),
@@ -32,20 +32,16 @@ const mapTransactionData = (
   }
 }
 
-const returnTxListData = (
-  data: Array<BlockTransaction>,
-  block: DetailedBlock,
-): Array<ParsedTx> => {
-  return data.map(tx => mapTransactionData(tx, block))
+const returnTxListData = (block: DetailedBlock): Array<ParsedTx> => {
+  return block.tx.map(tx => mapTransactionData(tx, block.blocktime))
 }
 
 const N3BlockTransactionsList: React.FC<{
-  list: Array<BlockTransaction>
   block: DetailedBlock
   loading: boolean
   network: string
   chain: string
-}> = ({ list, block, loading, network, chain }) => {
+}> = ({ block, loading, network, chain }) => {
   const width = useWindowWidth()
 
   const columns =
@@ -69,7 +65,7 @@ const N3BlockTransactionsList: React.FC<{
   return (
     <div id="BlockTransactionsList">
       <List
-        data={returnTxListData(list, block)}
+        data={returnTxListData(block)}
         rowId="hash"
         generateHref={(data): string =>
           `${ROUTES.TRANSACTION.url}/${chain}/${network}/${data.id}`

--- a/src/pages/block/Block.tsx
+++ b/src/pages/block/Block.tsx
@@ -35,9 +35,11 @@ const Block: React.FC<Props> = (props: Props) => {
   const [blockTimeState, setBlockTimeState] = useState('')
   const { block, isLoading } = blockState
 
+  const index = Number(hash ?? 1)
+
   useEffect(() => {
-    dispatch(fetchBlock(hash))
-  }, [dispatch, hash])
+    dispatch(fetchBlock(index))
+  }, [dispatch, index])
 
   useEffect(() => {
     const { block } = blockState

--- a/src/pages/block/Block.tsx
+++ b/src/pages/block/Block.tsx
@@ -169,7 +169,6 @@ const Block: React.FC<Props> = (props: Props) => {
 
                 <N3BlockTransactionsList
                   loading={isLoading}
-                  list={block.tx}
                   block={block}
                   network={network}
                   chain={chain}

--- a/src/reducers/blockReducer.ts
+++ b/src/reducers/blockReducer.ts
@@ -7,6 +7,7 @@ import {
   REQUEST_BLOCKS_SUCCESS,
   CLEAR_BLOCKS_LIST,
 } from '../actions/blockActions'
+import { BlockTransaction } from './transactionReducer'
 
 type Action = {
   type: string
@@ -43,15 +44,11 @@ export type Block = {
 export type DetailedBlock = {
   nextconsensus: string
   oversize: number
-  tx: []
+  tx: BlockTransaction[]
   previousblockhash: string
   index: number
   version: number
   nonce: string
-  script: {
-    invocation: string
-    verification: string
-  }
   size: number
   blocktime: number
   merkleroot: string

--- a/src/reducers/blockReducer.ts
+++ b/src/reducers/blockReducer.ts
@@ -11,7 +11,7 @@ import {
 type Action = {
   type: string
   receivedAt: Date
-  indexOrHash: string
+  index: number
   blockHeight: string
   json: {
     hash: string

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -128,7 +128,6 @@ export type BlockTransaction = {
   size: number
   time: number
   txid: string
-  type?: string
   hash: string
 }
 


### PR DESCRIPTION
This part updates `block` related code to use NeoRest. It also fixes types, reduces duplicate data passing around and clarifies props. 

specifically;
* `requestBlockSuccess()` expected a `Block` type while the reducer and consuming component (`N3BlockTransactionsList`) expected a `DetailedBlock` type. Now they all expect `DetailedBlock`
* Updated `DetailedBlock` to have a type specification for the `tx` field
* Dropped `list` from `N3BlockTransactionsList` props and all functions consuming it later on because the same data is in the `block` prop under the `tx` field.
* the `indexOrHash` field in most block actions was actually always the block index as a string (could have been necessary when there was still N2 code, now it isn't). I renamed the field to make more sense now. Also the `/v2/` backend can only request a block by index using `NeoRest.block()` not by hash. Which is probably why they started using this manual fetching (```await fetch(`${GENERATE_BASE_URL()}/block/${indexOrHash}`)```)
