### PR TITLE
use dora-sdk-ts for contract detail page/logic

### DIFF
--- a/src/actions/contractActions.ts
+++ b/src/actions/contractActions.ts
@@ -166,7 +166,7 @@ export function fetchContract(hash: string) {
       dispatch(requestContract(hash))
 
       try {
-        const network = store.getState().network.network
+        const { network } = store.getState().network
         const contract = await NeoRest.contract(hash, network)
         const stats = await NeoRest.contractStats(hash, network)
 

--- a/src/actions/contractActions.ts
+++ b/src/actions/contractActions.ts
@@ -1,15 +1,19 @@
 import { Dispatch, Action } from 'redux'
 import { ThunkDispatch } from 'redux-thunk'
 
-import { GENERATE_BASE_URL, SUPPORTED_PLATFORMS } from '../constants'
-import { Contract, State } from '../reducers/contractReducer'
+import { SUPPORTED_PLATFORMS } from '../constants'
+import { Contract, InvocationStat, State } from '../reducers/contractReducer'
 import { sortSingleListByDate } from '../utils/time'
 import { NeoLegacyREST, NeoRest } from '@cityofzion/dora-ts/dist/api'
-import { ContractsResponse } from '@cityofzion/dora-ts/dist/interfaces/api/neo'
+import {
+  ContractResponse,
+  ContractsResponse,
+} from '@cityofzion/dora-ts/dist/interfaces/api/neo'
 import {
   ContractsResponse as NLContractsResponse,
   InvocationStatsResponse,
 } from '@cityofzion/dora-ts/dist/interfaces/api/neo_legacy'
+import { store } from '../store'
 
 export const REQUEST_CONTRACT = 'REQUEST_CONTRACT'
 export const requestContract =
@@ -33,7 +37,7 @@ export const requestContracts =
 
 export const REQUEST_CONTRACT_SUCCESS = 'REQUEST_CONTRACT_SUCCESS'
 export const requestContractSuccess =
-  (hash: string, json: Contract) =>
+  (hash: string, json: { contract: ContractResponse; stats: InvocationStat }) =>
   (dispatch: Dispatch): void => {
     dispatch({
       type: REQUEST_CONTRACT_SUCCESS,
@@ -153,7 +157,7 @@ export const resetContractState =
     })
   }
 
-export function fetchContract(hash: string, populateStates = true) {
+export function fetchContract(hash: string) {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,
     getState: () => { contract: State },
@@ -162,27 +166,16 @@ export function fetchContract(hash: string, populateStates = true) {
       dispatch(requestContract(hash))
 
       try {
-        const response = await fetch(`${GENERATE_BASE_URL()}/contract/${hash}`)
+        const network = store.getState().network.network
+        const contract = await NeoRest.contract(hash, network)
+        const stats = await NeoRest.contractStats(hash, network)
 
-        const json = await response.json()
-
-        if (populateStates) {
-          const invocationStatsResponse = await fetch(
-            `${GENERATE_BASE_URL()}/contract_stats/${hash}`,
-          )
-
-          const invocationStats = await invocationStatsResponse
-            .json()
-            .catch(error => {
-              console.error('An error occurred fetching invocation stats.', {
-                error,
-              })
-            })
-
-          json.invocationStats = invocationStats || null
-        }
-
-        dispatch(requestContractSuccess(hash, json))
+        dispatch(
+          requestContractSuccess(hash, {
+            contract,
+            stats: stats as InvocationStat,
+          }),
+        )
       } catch (e) {
         dispatch(requestContractError(hash, e))
       }

--- a/src/pages/contract/Contract.tsx
+++ b/src/pages/contract/Contract.tsx
@@ -31,7 +31,7 @@ const Contract: React.FC<Props> = (props: Props) => {
   const contractsState = useSelector(
     ({ contract }: { contract: ContractState }) => contract,
   )
-  const { contract, isLoading } = contractsState
+  const { contract, isLoading, contractStats } = contractsState
 
   function getAddressLink(): string {
     if (contract && chain === 'neo3') {
@@ -93,12 +93,12 @@ const Contract: React.FC<Props> = (props: Props) => {
             </div>
           </div>
 
-          {contract && contract.invocationStats && (
+          {contract && contractStats && (
             <div id="contract-invocations-graph-container">
               <div className="section-label" style={{ marginBottom: -20 }}>
                 LAST 30 DAYS INVOCATIONS
               </div>
-              <InvocationGraph data={contract.invocationStats} />
+              <InvocationGraph data={contractStats} />
             </div>
           )}
 

--- a/src/reducers/contractReducer.ts
+++ b/src/reducers/contractReducer.ts
@@ -44,7 +44,6 @@ export type State = {
   totalCount: number
 }
 
-// used in fetchContracts (plural) and Contracts list
 export type Contract = {
   block: number
   time: number

--- a/src/reducers/contractReducer.ts
+++ b/src/reducers/contractReducer.ts
@@ -9,15 +9,19 @@ import {
   REQUEST_CONTRACTS_INVOCATIONS,
   REQUEST_CONTRACTS_INVOCATIONS_SUCCESS,
 } from '../actions/contractActions'
-import { InvocationStatsResponse } from '@cityofzion/dora-ts/dist/interfaces/api/neo_legacy'
 import { NEF } from '@cityofzion/dora-ts/dist/interfaces/api/neo/interface'
+import {
+  ContractResponse,
+  InvocationStatsResponse,
+} from '@cityofzion/dora-ts/dist/interfaces/api/neo'
 
 type Action = {
   type: string
   receivedAt: Date
   hash: string
   json: {
-    hash: string
+    contract: ContractResponse
+    stats: InvocationStat
   }
   page: number
 }
@@ -33,12 +37,14 @@ export type State = {
   all: Contract[]
   lastUpdated: Date | null
   contract: DetailedContract | null
+  contractStats: InvocationStat
   contractsInvocations: InvocationStats[]
   page: number
   hasFetchedContractsInvocations: boolean
   totalCount: number
 }
 
+// used in fetchContracts (plural) and Contracts list
 export type Contract = {
   block: number
   time: number
@@ -127,6 +133,7 @@ export default (
     hasFetchedContractsInvocations: false,
     lastUpdated: null,
     contract: null,
+    contractStats: {},
     page: 1,
     totalCount: 0,
   },
@@ -146,7 +153,8 @@ export default (
     case REQUEST_CONTRACT_SUCCESS:
       return Object.assign({}, state, {
         isLoading: false,
-        contract: action.json,
+        contract: action.json.contract,
+        contractStats: action.json.stats,
         lastUpdated: action.receivedAt,
         cached: {
           [action.json.hash]: action.json,


### PR DESCRIPTION
Unlike the previous PRs in this series where the `NeoRest` responses would get transformed into custom internal interfaces/objects (e.g. `ParsedTX`), this does not happen for the contract detail page this PR addresses. For that reason we can actually directly use the contract response object from the `NeoRest` API calls. 

The old code relied on appending the invocation stats to the contract object. In this PR they are kept separate to keep the typing clean and matching the actual objects.