### PR TITLE
zap-n2: Change platform to network

### DIFF
--- a/src/components/platform-cell/PlatformCell.tsx
+++ b/src/components/platform-cell/PlatformCell.tsx
@@ -17,7 +17,7 @@ const PlatformCell = ({
           <div className="neo3-platform-cell">
             <img src={Neo3} alt="NEO 3" />
             <span>
-              Neo <small>(Testnet) </small>
+              <small>Testnet</small>
             </span>
           </div>
         )
@@ -26,7 +26,7 @@ const PlatformCell = ({
           <div className="neo3-platform-cell">
             <img src={Neo3} alt="NEO 3" />
             <span>
-              Neo <small>(Mainnet) </small>
+              <small>Mainnet</small>
             </span>
           </div>
         )

--- a/src/pages/blocks/Blocks.tsx
+++ b/src/pages/blocks/Blocks.tsx
@@ -118,7 +118,7 @@ const Blocks: React.FC<MatchParams> = props => {
   const columns =
     width > 768
       ? [
-          { name: 'Platform', accessor: 'platform' },
+          { name: 'Network', accessor: 'platform' },
           {
             name: 'Height',
             accessor: 'index',
@@ -128,7 +128,7 @@ const Blocks: React.FC<MatchParams> = props => {
           { name: 'Size', accessor: 'size' },
         ]
       : [
-          { name: 'Platform', accessor: 'platform' },
+          { name: 'Network', accessor: 'platform' },
           {
             name: 'Height',
             accessor: 'index',

--- a/src/pages/contracts/Contracts.tsx
+++ b/src/pages/contracts/Contracts.tsx
@@ -98,7 +98,7 @@ const Contracts: React.FC<{}> = () => {
   const columns =
     width > 768
       ? [
-          { name: 'Platform', accessor: 'platform' },
+          { name: 'Network', accessor: 'platform' },
           { name: 'Name', accessor: 'name' },
           { name: 'Symbol', accessor: 'symbol' },
 
@@ -106,7 +106,7 @@ const Contracts: React.FC<{}> = () => {
           { name: 'Created on', accessor: 'time' },
         ]
       : [
-          { name: 'Platform', accessor: 'platform' },
+          { name: 'Network', accessor: 'platform' },
           { name: 'Name', accessor: 'name' },
         ]
 

--- a/src/pages/transactions/Transactions.tsx
+++ b/src/pages/transactions/Transactions.tsx
@@ -108,14 +108,14 @@ const Transactions: React.FC<{}> = () => {
   const columns =
     width > 768
       ? [
-          { name: 'Platform', accessor: 'platform' },
+          { name: 'Network', accessor: 'platform' },
           { name: 'Type', accessor: 'parsedType' },
           { name: 'Transaction ID', accessor: 'txid' },
           { name: 'Size', accessor: 'size' },
           { name: 'Completed on', accessor: 'time' },
         ]
       : [
-          { name: 'Platform', accessor: 'platform' },
+          { name: 'Network', accessor: 'platform' },
           { name: 'Transaction ID', accessor: 'txid' },
           { name: 'Size', accessor: 'size' },
         ]


### PR DESCRIPTION
This fixes modifies the Platform column, both header name and row names from

![image](https://github.com/CityOfZion/dora/assets/6625537/4a5979a4-eca6-4209-9dcc-25323f743d4a)

to

![image](https://github.com/CityOfZion/dora/assets/6625537/3136f61a-8688-4fdd-a406-cca19d5f91f6)

because now we only have Neo N3