### PR TITLE
make asset clickable in assets list of an address

### DIFF
--- a/src/actions/addressActions.ts
+++ b/src/actions/addressActions.ts
@@ -93,6 +93,7 @@ type ParsedBalanceData = {
   name: string
   balance: string | number
   symbol: string
+  asset: string
 }
 
 export function fetchAddress(address: string, chain: string) {
@@ -122,6 +123,7 @@ export function fetchAddress(address: string, chain: string) {
             name,
             symbol,
             balance,
+            asset: balanceData.asset,
           })
         }
 

--- a/src/pages/address/Address.scss
+++ b/src/pages/address/Address.scss
@@ -143,6 +143,7 @@
       display: flex;
       display: -webkit-flex;
       flex-direction: column;
+      cursor: pointer;
     }
 
     .balance-symbol {

--- a/src/pages/address/fragments/assets/AddressAssets.tsx
+++ b/src/pages/address/fragments/assets/AddressAssets.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { RouteComponentProps, withRouter } from 'react-router-dom'
+import { RouteComponentProps, withRouter, useHistory } from 'react-router-dom'
 
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
 import { toBigNumber } from '../../../../utils/formatter'
@@ -31,13 +31,18 @@ interface MatchParams {
 type Props = RouteComponentProps<MatchParams>
 
 const AddressAssets: React.FC<Props> = props => {
-  const { hash, chain } = props.match.params
+  const { hash, chain, network } = props.match.params
   useUpdateNetworkState(props)
   const dispatch = useDispatch()
   const addressState = useSelector(
     ({ address }: { address: AddressState }) => address,
   )
   const { balance, isLoading } = addressState
+
+  const history = useHistory()
+  function handleContractClick(contractHash: string) {
+    history.push(`/contract/${chain}/${network}/${contractHash}`)
+  }
 
   useEffect(() => {
     dispatch(fetchAddress(hash, chain))
@@ -57,7 +62,10 @@ const AddressAssets: React.FC<Props> = props => {
                 <div className="icon-container">
                   {getTransferLogo(balance.symbol, chain)}
                 </div>
-                <div className="balance-infos">
+                <div
+                  className="balance-infos"
+                  onClick={() => handleContractClick(balance.asset)}
+                >
                   <span className="balance-symbol">{balance.symbol}</span>
                   {balance.name && (
                     <span className="balance-name">{balance.name}</span>


### PR DESCRIPTION
closes #471 

This PR makes the name/symbol area clickable

![image](https://github.com/CityOfZion/dora/assets/6625537/46a04fbb-0bf2-4791-8d3d-e7b0d0b7d223)
