### PR TITLE
remove contracts counts stats

### DIFF
--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -190,15 +190,7 @@ export const List: React.FC<ListProps> = ({
 
   return (
     <div className="data-list-container">
-      {countConfig && (
-        <div className="data-list-count-stats">
-          {' '}
-          {countConfig.label} 1 to {data.length}{' '}
-          {!!countConfig.total
-            ? `of ${countConfig.total.toLocaleString()}`
-            : null}
-        </div>
-      )}
+      {countConfig && <div className="data-list-count-stats"> </div>}
       <div className="data-list" style={gridstyle}>
         {columns.map((column, i) => {
           return orderData ? (


### PR DESCRIPTION
This removes the "Contracts n of m" text because 
1) it's not updating anymore after changing the pagination style from "load more" to "pages" in [#631](https://github.com/CityOfZion/dora/pull/631)
2) it is redundant with the new pagination component

Before
![image](https://github.com/CityOfZion/dora/assets/6625537/7507e4c5-8216-4176-ac49-60ecd1ae9c30)

After
![image](https://github.com/CityOfZion/dora/assets/6625537/30a86ddd-02c0-4b0f-b878-1135a7f08495)

I did not remove the whole `div` because then the layout would change. This is my quick fix