### PR TITLE
skip requesting testnet invocation stats

### DIFF
--- a/src/actions/contractActions.ts
+++ b/src/actions/contractActions.ts
@@ -232,7 +232,7 @@ export function fetchContracts(network: string, protocol: string, page = 1) {
   }
 }
 
-export function fetchContractsInvocations() {
+export function fetchMainnetContractsInvocations() {
   return async (
     dispatch: ThunkDispatch<State, void, Action>,
     getState: () => { contract: State },
@@ -240,23 +240,16 @@ export function fetchContractsInvocations() {
     if (shouldFetchContractsInvocations(getState())) {
       dispatch(requestContractsInvocations())
       try {
-        const res = await Promise.all(
-          SUPPORTED_PLATFORMS.map(async ({ network, protocol }) => {
-            const result = await NeoRest.invocationStats(network)
-            if (result) {
-              return result.map(d => ({
-                ...d,
-                network,
-                protocol,
-              }))
-            }
-          }),
-        )
-        const cleanedContracts = res.flat().filter(r => r !== undefined)
-        const sortedContract = cleanedContracts
+        const invocationResponse = await NeoRest.invocationStats('mainnet')
+        const result = invocationResponse.map(r => ({
+          ...r,
+          network: 'mainnet',
+          protocol: 'neo3',
+        }))
+        const sortedContracts = result
           .flat()
           .sort((a, b) => (a!.count < b!.count ? 1 : -1))
-        dispatch(requestContractsInvocationsSuccess(sortedContract))
+        dispatch(requestContractsInvocationsSuccess(sortedContracts))
       } catch (e: any) {
         dispatch(requestContractsInvocationsError(e))
       }

--- a/src/components/contract-invocation/ContractsInvocations.tsx
+++ b/src/components/contract-invocation/ContractsInvocations.tsx
@@ -7,7 +7,7 @@ import { MOCK_CONTRACTS_INVOCATIONS_DATA } from '../../utils/mockData'
 import List from '../../components/list/List'
 import './ContractsInvocations.scss'
 import { State as ContractState } from '../../reducers/contractReducer'
-import { fetchContractsInvocations } from '../../actions/contractActions'
+import { fetchMainnetContractsInvocations } from '../../actions/contractActions'
 import useWindowWidth from '../../hooks/useWindowWidth'
 import { Link } from 'react-router-dom'
 import { ROUTES } from '../../constants'
@@ -101,7 +101,8 @@ const ContractsInvocations: React.FC<{}> = () => {
   }
 
   useEffect(() => {
-    if (!contractsInvocations.length) dispatch(fetchContractsInvocations())
+    if (!contractsInvocations.length)
+      dispatch(fetchMainnetContractsInvocations())
   }, [contractsInvocations, dispatch])
 
   const columns =


### PR DESCRIPTION
The front page has a 24h contract invocation stats section. This section is _only_ showing MainNet data. However, in the background testnet data was also requested. The particular testnet endpoint happens to be significant slower at ~3+ seconds vs 24ms for MainNet
![Screenshot from 2024-06-04 09-59-01](https://github.com/CityOfZion/dora/assets/6625537/a69d6030-bb02-4151-849f-8ed6e498dc0f)

The quickfix to this problem is not asking for Testnet data as we're not even using the data.