### PR TITLE
fix NTF list after GhostMarket API change

### DIFF
--- a/src/actions/nftActions.ts
+++ b/src/actions/nftActions.ts
@@ -23,7 +23,7 @@ interface GhostMarketNFT {
     addressId: number
   }
   apiUrl?: string
-  ownerships: {
+  ownership: {
     owner: {
       address?: string
       addressVerified?: boolean
@@ -32,7 +32,7 @@ interface GhostMarketNFT {
       addressId?: number
     }
     amount?: string
-  }[]
+  }
   nftType: string[]
   collection: {
     name?: string
@@ -115,9 +115,9 @@ async function getGhostMarketNFT(
         symbol: nft.contract.symbol || '',
         contract: nft.contract.hash || '',
         id: nft.tokenId || '',
-        creatorName: nft.ownerships[0].owner.offchainName || '',
+        creatorName: nft.ownership.owner.offchainName || '',
         creatorAddress: nft.creator.address || '',
-        ownerAddress: nft.ownerships[0].owner.address || '',
+        ownerAddress: nft.ownership.owner.address || '',
         apiUrl: nft.apiUrl || '',
         collection: {
           image: nft.collection.logoUrl || '',


### PR DESCRIPTION
GhostMarket seem to have changed their API format. This fixes the NFT list.

Waiting on GM to give a list of changes to see if anything else changed. For now deploying this.