### PR TITLE
display mint/burn address correctly

### DIFF
--- a/src/components/transfer/Transfer.tsx
+++ b/src/components/transfer/Transfer.tsx
@@ -43,6 +43,9 @@ const Transfer = ({ transfers = [], network, transaction, chain }: Props) => {
   const isMobileOrTablet = width <= 990
 
   function handleAddressClick(address: string) {
+    if (address === 'mint' || address === 'burn') {
+      return
+    }
     history.push(`/address/${chain}/${network}/${address}`)
   }
 

--- a/src/pages/transaction/Transaction.tsx
+++ b/src/pages/transaction/Transaction.tsx
@@ -72,12 +72,18 @@ const parseNeo3TransactionData = async (
             }
           }
 
-          const from_address = neo3_getAddressFromSriptHash(
-            String(notification.state.value[0].value),
-          )
-          const to_address = neo3_getAddressFromSriptHash(
-            String(notification.state.value[1].value),
-          )
+          let from_address = 'mint'
+          if (notification.state.value[0].value !== undefined) {
+            from_address = neo3_getAddressFromSriptHash(
+              String(notification.state.value[0].value),
+            )
+          }
+          let to_address = 'burn'
+          if (notification.state.value[1].value !== undefined) {
+            to_address = neo3_getAddressFromSriptHash(
+              String(notification.state.value[1].value),
+            )
+          }
           transfers.push({
             name,
             symbol,


### PR DESCRIPTION
When a transfer occurs from the `mint` or to the `burn` address it shows a wrong address
![image](https://github.com/user-attachments/assets/533309b5-aea0-41c3-a2e0-f067886669d9)


This PR fixes that to show `mint` or `burn`
![image](https://github.com/user-attachments/assets/ecd72d91-c6b7-4d60-a95a-17640b8d237b)

It also prevents clicking on the `mint`/`burn` address