### PR TITLE
Update select chevron colour

### DIFF
--- a/src/components/select/customStyles.ts
+++ b/src/components/select/customStyles.ts
@@ -11,6 +11,10 @@ export const customStyles = {
   indicatorSeparator: (): CSSProperties => ({
     display: 'none',
   }),
+  dropdownIndicator: (provided: CSSProperties, _: any) => ({
+    ...provided,
+    color: 'white',
+  }),
   indicatorsContainer: (): CSSProperties => ({
     background: '#D355E7',
     borderRadius: '0 80px 80px 0',


### PR DESCRIPTION
I asked Ben to review the global network selection from a designer perspective and as feedback he asked to update the chevron

<img width="659" height="418" alt="image" src="https://github.com/user-attachments/assets/2ca07a77-5b75-4af4-9de8-8fb44734488e" />

This PR forces the same white colour