### PR TITLE
Resolve contract names prepending `0`

### DIFF
--- a/src/pages/contracts/Contracts.tsx
+++ b/src/pages/contracts/Contracts.tsx
@@ -42,14 +42,16 @@ const mapContractData = (contract: Contract): ParsedContract => {
     name: (): ReactElement => (
       <div className="contract-name-and-icon-row">
         {contract.protocol?.length &&
-          contract.hash.length &&
-          contract.symbol.length && (
-            <TokenIcon
-              blockchain={contract.protocol}
-              hash={contract.hash}
-              className="contract-icon"
-            />
-          )}
+        contract.hash.length &&
+        contract.symbol.length ? (
+          <TokenIcon
+            blockchain={contract.protocol}
+            hash={contract.hash}
+            className="contract-icon"
+          />
+        ) : (
+          <div className="contract-icon-stub"></div>
+        )}
 
         <div className="contract-name-label">
           {contract.name ||


### PR DESCRIPTION
#708 introduced an odd behaviour where `0` gets prepended to the contract name

<img width="620" height="958" alt="image" src="https://github.com/user-attachments/assets/a44accff-477b-4105-83f0-8de01773d665" />

This resolves that