### PR TITLE
update default `doraURL` of `NeoRest`

### DIFF
--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,6 +1,6 @@
 import { NeoRESTApi } from '@cityofzion/dora-ts/dist/api'
 
 export const NeoRest = new NeoRESTApi({
-  doraUrl: import.meta.env.VITE_API_HOST || 'https://dora.coz.io',
+  doraUrl: import.meta.env.VITE_API_HOST || 'https://api.coz.io',
   endpoint: import.meta.env.VITE_API_BASE_PATH || '/api/v2/neo3',
 })


### PR DESCRIPTION
This allows us to cleanup some cloud infra settings and also resolves the contract search issue mentioned on Discord