### PR TITLE
Limit search results to selected network filter

### DIFF
--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -7,11 +7,13 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { ROUTES, SEARCH_TYPES } from '../../constants'
 import useWindowWidth from '../../hooks/useWindowWidth'
 import { useBlockchainSearch } from '../../hooks/useBlockchainSearch'
+import useNetworkGlobalSelector from '../../hooks/useNetworkGlobalSelector'
 
 const Search: React.FC = () => {
   const navigate = useNavigate()
   const width = useWindowWidth()
   const [searchParams] = useSearchParams()
+  const { network } = useNetworkGlobalSelector()
 
   const { search } = useBlockchainSearch()
 
@@ -25,7 +27,7 @@ const Search: React.FC = () => {
   async function handleSearch(event: React.SyntheticEvent) {
     event.preventDefault()
 
-    const results = await search(text)
+    const results = await search(text, network)
 
     if (results.length === 1) {
       const routesOptions: Record<string, string> = {

--- a/src/hooks/useBlockchainSearch.ts
+++ b/src/hooks/useBlockchainSearch.ts
@@ -88,69 +88,34 @@ const options: SearchOptions[] = [
   },
 ]
 
-type SearchPrimaryOption = Omit<SearchOptions, 'validateFn'> & {
-  validateFn: (text: string) => { valid: boolean; text?: string }
-}
-
-const primaryOptions: SearchPrimaryOption[] = [
-  {
-    protocol: 'neo3',
-    network: 'mainnet',
-    type: 'contract',
-    fetchFn: (text: string) => NeoRest.contract(text, 'mainnet'),
-    validateFn: (text: string) => {
-      const nativeContractHex = nativeContracts.get(text.toLowerCase())
-
-      return { valid: !!nativeContractHex, text: nativeContractHex }
-    },
-  },
-  {
-    protocol: 'neo3',
-    network: 'testnet',
-    type: 'contract',
-    fetchFn: (text: string) => NeoRest.contract(text, 'testnet'),
-    validateFn: (text: string) => {
-      const nativeContractHex = nativeContracts.get(text.toLowerCase())
-
-      return { valid: !!nativeContractHex, text: nativeContractHex }
-    },
-  },
-]
-
 export const useBlockchainSearch = () => {
   const search = useCallback(async (text: string): Promise<any[]> => {
-    const cachedText = text
+    // lookup name to contract hash
+    const contractHash = nativeContracts.get(text.toLowerCase())
 
-    const filteredPrimaryOptions = primaryOptions.filter(option => {
-      const result = option.validateFn(cachedText)
-
-      if (typeof result.text === 'string') text = result.text
-
-      return result.valid
-    })
-
-    let filteredOptions: SearchOptions[] | SearchPrimaryOption[] =
-      filteredPrimaryOptions.length > 0 ? filteredPrimaryOptions : []
-
-    if (filteredOptions.length === 0) {
-      filteredOptions = options.filter(option => {
+    let searchOptions
+    if (contractHash === undefined) {
+      searchOptions = options.filter(option => {
         if (option.validateFn) {
           return option.validateFn(text)
         }
-
         return true
       })
+    } else {
+      searchOptions = options.filter(option => {
+        return option.type === 'contract'
+      })
+      text = contractHash
+    }
+
+    if (searchOptions.length === 0) {
+      return []
     }
 
     const searchResults: SearchResult[] = []
-
-    if (filteredOptions.length === 0) {
-      return searchResults
-    }
-
     //execute the search across the search scope
     await Promise.allSettled(
-      filteredOptions.map(async ({ fetchFn, ...options }) => {
+      searchOptions.map(async ({ fetchFn, ...options }) => {
         const fetchResponse = await fetchFn(text)
 
         if (!fetchResponse || isEmpty(fetchResponse)) {

--- a/src/hooks/useBlockchainSearch.ts
+++ b/src/hooks/useBlockchainSearch.ts
@@ -2,14 +2,14 @@ import { useCallback } from 'react'
 import { NeoRest } from '../rest'
 import { isEmpty } from 'lodash'
 import { u, wallet } from '@cityofzion/neon-js'
-import { nativeContracts } from '../constants'
+import { nativeContracts, SEARCH_TYPES } from '../constants'
 
 type SearchOptions = {
   protocol: string
   network: string
   type: string
   fetchFn: (text: string) => Promise<any>
-  validateFn?: (text: string) => boolean
+  validateFn: (text: string) => boolean
 }
 
 export type SearchResult = Omit<SearchOptions, 'fetchFn' | 'validateFn'> & {
@@ -21,7 +21,7 @@ const options: SearchOptions[] = [
   {
     protocol: 'neo3',
     network: 'testnet',
-    type: 'block',
+    type: SEARCH_TYPES.BLOCK,
     fetchFn: (text: string) => NeoRest.block(text as any, 'testnet'),
     validateFn: (text: string) => {
       const blockNumber = parseInt(text, 10)
@@ -34,28 +34,28 @@ const options: SearchOptions[] = [
   {
     protocol: 'neo3',
     network: 'testnet',
-    type: 'balance',
+    type: SEARCH_TYPES.BALANCE,
     fetchFn: (text: string) => NeoRest.balance(text, 'testnet'),
     validateFn: (text: string) => wallet.isAddress(text),
   },
   {
     protocol: 'neo3',
     network: 'testnet',
-    type: 'contract',
+    type: SEARCH_TYPES.CONTRACT,
     fetchFn: (text: string) => NeoRest.contract(text, 'testnet'),
     validateFn: (text: string) => u.isHex(u.remove0xPrefix(text)),
   },
   {
     protocol: 'neo3',
     network: 'testnet',
-    type: 'transaction',
+    type: SEARCH_TYPES.TRANSACTION,
     fetchFn: (text: string) => NeoRest.transaction(text, 'testnet'),
     validateFn: (text: string) => u.isHex(u.remove0xPrefix(text)),
   },
   {
     protocol: 'neo3',
     network: 'mainnet',
-    type: 'block',
+    type: SEARCH_TYPES.BLOCK,
     fetchFn: (text: string) => NeoRest.block(text as any, 'mainnet'),
     validateFn: (text: string) => {
       const blockNumber = parseInt(text, 10)
@@ -68,72 +68,74 @@ const options: SearchOptions[] = [
   {
     protocol: 'neo3',
     network: 'mainnet',
-    type: 'balance',
+    type: SEARCH_TYPES.BALANCE,
     fetchFn: (text: string) => NeoRest.balance(text, 'mainnet'),
     validateFn: (text: string) => wallet.isAddress(text),
   },
   {
     protocol: 'neo3',
     network: 'mainnet',
-    type: 'contract',
+    type: SEARCH_TYPES.CONTRACT,
     fetchFn: (text: string) => NeoRest.contract(text, 'mainnet'),
     validateFn: (text: string) => u.isHex(u.remove0xPrefix(text)),
   },
   {
     protocol: 'neo3',
     network: 'mainnet',
-    type: 'transaction',
+    type: SEARCH_TYPES.TRANSACTION,
     fetchFn: (text: string) => NeoRest.transaction(text as any, 'mainnet'),
     validateFn: (text: string) => u.isHex(u.remove0xPrefix(text)),
   },
 ]
 
 export const useBlockchainSearch = () => {
-  const search = useCallback(async (text: string): Promise<any[]> => {
-    // lookup name to contract hash
-    const contractHash = nativeContracts.get(text.toLowerCase())
+  const search = useCallback(
+    async (text: string, network: string): Promise<any[]> => {
+      // lookup native contract convenience name to contract hash
+      const contractHash = nativeContracts.get(text.toLowerCase())
 
-    let searchOptions
-    if (contractHash === undefined) {
-      searchOptions = options.filter(option => {
-        if (option.validateFn) {
-          return option.validateFn(text)
-        }
-        return true
-      })
-    } else {
-      searchOptions = options.filter(option => {
-        return option.type === 'contract'
-      })
-      text = contractHash
-    }
-
-    if (searchOptions.length === 0) {
-      return []
-    }
-
-    const searchResults: SearchResult[] = []
-    //execute the search across the search scope
-    await Promise.allSettled(
-      searchOptions.map(async ({ fetchFn, ...options }) => {
-        const fetchResponse = await fetchFn(text)
-
-        if (!fetchResponse || isEmpty(fetchResponse)) {
-          return
-        }
-
-        searchResults.push({
-          response: fetchResponse,
-          network: options.network,
-          protocol: options.protocol,
-          type: options.type,
-          text,
+      let searchOptions
+      if (contractHash === undefined) {
+        searchOptions = options.filter(option => {
+          return option.network === network && option.validateFn(text)
         })
-      }),
-    )
+      } else {
+        searchOptions = options.filter(option => {
+          return (
+            option.network === network && option.type === SEARCH_TYPES.CONTRACT
+          )
+        })
+        text = contractHash
+      }
 
-    return searchResults
-  }, [])
+      if (searchOptions.length === 0) {
+        return []
+      }
+
+      const searchResults: SearchResult[] = []
+      //execute the search across the search scope
+      await Promise.allSettled(
+        searchOptions.map(async ({ fetchFn, ...options }) => {
+          const fetchResponse = await fetchFn(text)
+
+          if (!fetchResponse || isEmpty(fetchResponse)) {
+            return
+          }
+
+          searchResults.push({
+            response: fetchResponse,
+            network: options.network,
+            protocol: options.protocol,
+            type: options.type,
+            text,
+          })
+        }),
+      )
+
+      return searchResults
+    },
+    [],
+  )
 
   return { search }
 }

--- a/src/hooks/useBlockchainSearch.ts
+++ b/src/hooks/useBlockchainSearch.ts
@@ -95,7 +95,7 @@ export const useBlockchainSearch = () => {
       const contractHash = nativeContracts.get(text.toLowerCase())
 
       let searchOptions
-      if (contractHash === undefined) {
+      if (!contractHash) {
         searchOptions = options.filter(option => {
           return option.network === network && option.validateFn(text)
         })

--- a/src/pages/search-results/SearchResults.tsx
+++ b/src/pages/search-results/SearchResults.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../hooks/useBlockchainSearch'
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
 import { NoResult } from '../../components/no-result/NoResult'
+import useNetworkGlobalSelector from '../../hooks/useNetworkGlobalSelector'
 
 type PlatformElementProps = { network: string }
 
@@ -164,6 +165,8 @@ const SearchResults: React.FC = () => {
 
   const [results, setResults] = React.useState<SearchResult[] | undefined>()
 
+  const { network } = useNetworkGlobalSelector()
+
   useEffect(() => {
     async function handle() {
       if (!searchText || isSearchingRef.current) return
@@ -175,7 +178,7 @@ const SearchResults: React.FC = () => {
           setResults(state.results)
           return
         }
-        const result = await search(searchText)
+        const result = await search(searchText, network)
         setResults(result)
       } catch (error) {
         console.error(error)


### PR DESCRIPTION
close #703

I changed a bit more than just searching based on the selected network. Specifically,

1. applied the same constants the search type of the `options` as used by the logic that consumes the search results i.e.
https://github.com/CityOfZion/dora/blob/38c48049f689302075cad7625528dd500a936105/src/components/search/Search.tsx#L44-L45
2. removed optionality of `validateFn`. It was never undefined anywhere and would lead to unnecessary checking logic like
   ```js
        if (option.validateFn) {
          return option.validateFn(text)
        }
   ```
3. I simplified the search callback code. I initially did this to make it easier for me to debug the contract search issue discussed on Discord. I happened to append the other logic on top of this and honestly I think this is easier to read for the future as well. 

   Having another type (`SearchPrimaryOption`) really made it harder to read for what is essentially 1 `map` lookup that determins to use all search types or only the `CONTRACT` search type.